### PR TITLE
[WIP]: Wrap more of the Obj-C Runtime

### DIFF
--- a/src/ObjectiveC-Cocoa/CocoaApplication.class.st
+++ b/src/ObjectiveC-Cocoa/CocoaApplication.class.st
@@ -7,7 +7,7 @@ Class {
 	#pools : [
 		'CocoaConstants'
 	],
-	#category : #ObjectiveC-Cocoa
+	#category : #'ObjectiveC-Cocoa'
 }
 
 { #category : #accessing }

--- a/src/ObjectiveC-Cocoa/CocoaConstants.class.st
+++ b/src/ObjectiveC-Cocoa/CocoaConstants.class.st
@@ -8,7 +8,7 @@ Class {
 		'NSSquareStatusItemLength',
 		'NSVariableStatusItemLength'
 	],
-	#category : #ObjectiveC-Cocoa
+	#category : #'ObjectiveC-Cocoa'
 }
 
 { #category : #'class initialization' }

--- a/src/ObjectiveC-Cocoa/CocoaMorphView.class.st
+++ b/src/ObjectiveC-Cocoa/CocoaMorphView.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'morph'
 	],
-	#category : #ObjectiveC-Cocoa
+	#category : #'ObjectiveC-Cocoa'
 }
 
 { #category : #private }

--- a/src/ObjectiveC-Cocoa/CocoaViewController.class.st
+++ b/src/ObjectiveC-Cocoa/CocoaViewController.class.st
@@ -4,7 +4,7 @@ Class {
 	#pools : [
 		'CocoaConstants'
 	],
-	#category : #ObjectiveC-Cocoa
+	#category : #'ObjectiveC-Cocoa'
 }
 
 { #category : #private }

--- a/src/ObjectiveC-Cocoa/CocoaWindowController.class.st
+++ b/src/ObjectiveC-Cocoa/CocoaWindowController.class.st
@@ -4,7 +4,7 @@ Class {
 	#pools : [
 		'CocoaConstants'
 	],
-	#category : #ObjectiveC-Cocoa
+	#category : #'ObjectiveC-Cocoa'
 }
 
 { #category : #private }

--- a/src/ObjectiveC-Cocoa/CoreGraphicsLibrary.class.st
+++ b/src/ObjectiveC-Cocoa/CoreGraphicsLibrary.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #CoreGraphicsLibrary,
 	#superclass : #FFILibrary,
-	#category : #ObjectiveC-Cocoa
+	#category : #'ObjectiveC-Cocoa'
 }
 
 { #category : #'accessing platform' }

--- a/src/ObjectiveC-Cocoa/MacOSXAlertDelegate.class.st
+++ b/src/ObjectiveC-Cocoa/MacOSXAlertDelegate.class.st
@@ -1,10 +1,7 @@
 Class {
 	#name : #MacOSXAlertDelegate,
-	#superclass : #Object,
-	#instVars : [
-		'proxy'
-	],
-	#category : #ObjectiveC-Cocoa-Examples
+	#superclass : #ObjCProxyObject,
+	#category : #'ObjectiveC-Cocoa-Examples'
 }
 
 { #category : #example }
@@ -139,9 +136,4 @@ MacOSXAlertDelegate >> alertDidEnd: alert  returnCode: returnCode contextInfo: c
 	<objCSignature: #(void (id alert, int returnCode, void* contextInfo))>
 
 	#NSApplication inObjC sharedApplication stopModalWithCode: returnCode
-]
-
-{ #category : #accessing }
-MacOSXAlertDelegate >> proxy [
-	^ proxy
 ]

--- a/src/ObjectiveC-Cocoa/MacOSXWindowDelegate.class.st
+++ b/src/ObjectiveC-Cocoa/MacOSXWindowDelegate.class.st
@@ -1,10 +1,7 @@
 Class {
 	#name : #MacOSXWindowDelegate,
-	#superclass : #Object,
-	#instVars : [
-		'proxy'
-	],
-	#category : #ObjectiveC-Cocoa-Examples
+	#superclass : #ObjCProxyObject,
+	#category : #'ObjectiveC-Cocoa-Examples'
 }
 
 { #category : #example }
@@ -42,12 +39,8 @@ MacOSXWindowDelegate class >> example [
 	{window. delegate} inspect. "Just to prevent GC"
 	window center.
 	window makeKeyAndOrderFront: ObjCObject null.
+	2 seconds asDelay wait.
 	pool release
-]
-
-{ #category : #accessing }
-MacOSXWindowDelegate >> proxy [
-	^ proxy
 ]
 
 { #category : #'event handling' }

--- a/src/ObjectiveC-Cocoa/NSPoint.class.st
+++ b/src/ObjectiveC-Cocoa/NSPoint.class.st
@@ -5,7 +5,7 @@ Class {
 		'OFFSET_X',
 		'OFFSET_Y'
 	],
-	#category : #ObjectiveC-Cocoa-Structure
+	#category : #'ObjectiveC-Cocoa-Structure'
 }
 
 { #category : #'field definition' }

--- a/src/ObjectiveC-Cocoa/NSRect.class.st
+++ b/src/ObjectiveC-Cocoa/NSRect.class.st
@@ -7,7 +7,7 @@ Class {
 		'OFFSET_X',
 		'OFFSET_Y'
 	],
-	#category : #ObjectiveC-Cocoa-Structure
+	#category : #'ObjectiveC-Cocoa-Structure'
 }
 
 { #category : #'field definition' }

--- a/src/ObjectiveC-Cocoa/package.st
+++ b/src/ObjectiveC-Cocoa/package.st
@@ -1,1 +1,1 @@
-Package { #name : #ObjectiveC-Cocoa }
+Package { #name : #'ObjectiveC-Cocoa' }

--- a/src/ObjectiveC-Tests/ObjCClassTest.class.st
+++ b/src/ObjectiveC-Tests/ObjCClassTest.class.st
@@ -17,29 +17,28 @@ ObjCClassTest >> test_conformsToProtocol [
 { #category : #test }
 ObjCClassTest >> test_copyIvarList [
 
-	| class |
+	| class hasExpectedItem |
 	class := #NSObject inObjC.
-	class copyIvarList.
-	"self assert:  equals: ."
+	hasExpectedItem := class copyIvarList anySatisfy: [ :e | e getName = 'isa' ].
+	self assert: hasExpectedItem
 ]
 
 { #category : #test }
 ObjCClassTest >> test_copyMethodList [
 
-	| class |
+	| class hasExpectedItem |
 	class := #NSObject inObjC.
-	self flag: 'How to pass int address?'.
-	class copyMethodList.
-	"self assert:  equals: ."
+	hasExpectedItem := class copyMethodList anySatisfy: [ :e | e getName getName = 'isEqualTo:' ].
+	self assert: hasExpectedItem
 ]
 
 { #category : #test }
 ObjCClassTest >> test_copyPropertyList [
 
-	| class |
+	| class hasExpectedItem |
 	class := #NSObject inObjC.
-	class copyProtocolList.
-	"self assert:  equals: ."
+	hasExpectedItem := class copyProtocolList anySatisfy: [ :e | e getName = 'NSObject' ].
+	self assert: hasExpectedItem
 ]
 
 { #category : #test }

--- a/src/ObjectiveC-Tests/ObjCClassTest.class.st
+++ b/src/ObjectiveC-Tests/ObjCClassTest.class.st
@@ -1,0 +1,165 @@
+Class {
+	#name : #ObjCClassTest,
+	#superclass : #TestCase,
+	#category : #'ObjectiveC-Tests-Core'
+}
+
+{ #category : #test }
+ObjCClassTest >> test_conformsToProtocol [
+
+	| class protocol |
+	class := #NSObject inObjC.
+	protocol := ObjCProtocol getProtocol: 'NSObject'.
+	self deny: protocol handle isNull description: 'Next line crashes VM; this general pattern seems to work in Obj-C'.
+	"self assert: (class conformsToProtocol: protocol)."
+]
+
+{ #category : #test }
+ObjCClassTest >> test_copyIvarList [
+
+	| class |
+	class := #NSObject inObjC.
+	class copyIvarList.
+	"self assert:  equals: ."
+]
+
+{ #category : #test }
+ObjCClassTest >> test_copyMethodList [
+
+	| class |
+	class := #NSObject inObjC.
+	self flag: 'How to pass int address?'.
+	class copyMethodList.
+	"self assert:  equals: ."
+]
+
+{ #category : #test }
+ObjCClassTest >> test_copyPropertyList [
+
+	| class |
+	class := #NSObject inObjC.
+	class copyProtocolList.
+	"self assert:  equals: ."
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getClassMethod [
+
+	| class |
+	class := #NSObject inObjC.
+	class getClassMethod: #alloc asObjCSelector.
+	"self assert:  equals: ."
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getClassVariable [
+
+	| class result |
+	class := #NSObject inObjC.
+	self assert: (class getClassVariable: 'nonexistent') handle isNull.
+	
+	result := class getClassVariable: 'existent'.
+	self assert: result getName = 'existent'.
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getInstanceSize [
+
+	| class result |
+	class := #NSObject inObjC.
+	result := class getInstanceSize.
+	self assert: result isNumber.
+	self assert: result > 0.
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getInstanceVariable [
+
+	| class result |
+	class := #NSObject inObjC.
+	result := class getInstanceVariable: 'isa'.
+	self assert: result getName = 'isa'.
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getIvarLayout [
+
+	| class |
+	class := #NSObject inObjC.
+	self assert: class getIvarLayout equals: ExternalAddress null
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getMethodImplementation [
+
+	| class |
+	class := #NSObject inObjC.
+	self flag: 'How does getMethodImplementation: differ from class_getMethodImplementation_stret?'.
+	class getMethodImplementation: #conformsToProtocol: asObjCSelector.
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getName [
+
+	| class |
+	class := #NSObject inObjC.
+	self assert: class getName equals: 'NSObject'.
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getProperty [
+
+	| class |
+	class := #NSObject inObjC.
+	self assert: (class getProperty: 'description') getName equals: 'description'.
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getSuperclass [
+
+	| class |
+	class := #NSObject inObjC.
+	self assert: class getSuperclass name equals: 'nil'.
+	self flag: 'I''d like the assert to be: 
+		self assert: class class_getSuperclass equals: ObjCObject nil object_getClass
+	But the two don''t equate; not sure if it''s worth it'.
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getVersion [
+
+	| class |
+	class := #NSObject inObjC.
+	self assert: class getVersion equals: 0.
+]
+
+{ #category : #test }
+ObjCClassTest >> test_getWeakIvarLayout [
+
+	| class |
+	class := #NSObject inObjC.
+	self assert: class getWeakIvarLayout equals: ExternalAddress null
+]
+
+{ #category : #test }
+ObjCClassTest >> test_isMetaClass [
+
+	| class |
+	class := #NSObject inObjC.
+	self assert: class getClass isMetaClass.
+	self deny: class isMetaClass.
+]
+
+{ #category : #test }
+ObjCClassTest >> test_objc_getClassList [
+
+	self assert: (ObjCClass objc_getClassList).
+]
+
+{ #category : #test }
+ObjCClassTest >> test_respondsToSelector [
+
+	| class |
+	class := #NSObject inObjC.
+	self assert: (class respondsToSelector: #conformsToProtocol: asObjCSelector).
+]

--- a/src/ObjectiveC-Tests/ObjCInstanceVariableTest.class.st
+++ b/src/ObjectiveC-Tests/ObjCInstanceVariableTest.class.st
@@ -1,0 +1,32 @@
+"
+An ObjCInstanceVariableTest is a test class for testing the behavior of ObjCInstanceVariable
+"
+Class {
+	#name : #ObjCInstanceVariableTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'ivar'
+	],
+	#category : #'ObjectiveC-Tests-Core'
+}
+
+{ #category : #test }
+ObjCInstanceVariableTest >> test_getName [
+
+	ivar := #NSObject inObjC getInstanceVariable: 'isa'.
+	self assert: ivar getName equals: 'isa'
+]
+
+{ #category : #test }
+ObjCInstanceVariableTest >> test_getOffset [
+
+	ivar := #NSObject inObjC getInstanceVariable: 'isa'.
+	self assert: ivar getOffset equals: 0
+]
+
+{ #category : #test }
+ObjCInstanceVariableTest >> test_getTypeEncoding [
+
+	ivar := #NSObject inObjC getInstanceVariable: 'isa'.
+	self assert: ivar getTypeEncoding equals: '#'
+]

--- a/src/ObjectiveC-Tests/ObjCLibraryTest.class.st
+++ b/src/ObjectiveC-Tests/ObjCLibraryTest.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #ObjCLibraryTest,
+	#superclass : #TestCase,
+	#category : #'ObjectiveC-Tests'
+}
+
+{ #category : #tests }
+ObjCLibraryTest >> testCopyClassNamesForImage [
+	| classNames |
+	classNames := ObjCLibrary uniqueInstance copyClassNamesForImage: '/usr/lib/libnetwork.dylib'.
+	self assert: classNames isNotEmpty.
+	self assert: (classNames includes: 'OS_nw_array')
+]
+
+{ #category : #tests }
+ObjCLibraryTest >> testCopyImageNames [
+	| result |
+	result := ObjCLibrary uniqueInstance copyImageNames.
+	self assert: result isNotEmpty.
+	self assert: result first isString
+]

--- a/src/ObjectiveC-Tests/ObjCMethodTest.class.st
+++ b/src/ObjectiveC-Tests/ObjCMethodTest.class.st
@@ -1,0 +1,80 @@
+Class {
+	#name : #ObjCMethodTest,
+	#superclass : #TestCase,
+	#category : #'ObjectiveC-Tests-Core'
+}
+
+{ #category : #tests }
+ObjCMethodTest >> test_copyArgumentType [
+	| method |
+	method := #NSObject inObjC copyMethodList detect: [ :e | e getName name = 'isEqualTo:' ].
+	self assert: (method copyArgumentType: 1) equals: ':'.
+	self assert: (method copyArgumentType: 2) equals: '@'.
+	self assert: (method copyArgumentType: 3) equals: nil.
+]
+
+{ #category : #tests }
+ObjCMethodTest >> test_copyReturnType [
+	| method |
+	method := #NSObject inObjC copyMethodList detect: [ :e | e getName name = 'isEqualTo:' ].
+	self assert: method copyReturnType equals: 'c'
+]
+
+{ #category : #tests }
+ObjCMethodTest >> test_getArgumentType [
+	| method |
+	method := #NSObject inObjC copyMethodList detect: [ :e | e getName name = 'isEqualTo:' ].
+	self assert: (method getArgumentTypeAt: 1) equals: ':'.
+	self assert: (method getArgumentTypeAt: 2) equals: '@'.
+	self assert: (method getArgumentTypeAt: 3) equals: ''.
+]
+
+{ #category : #tests }
+ObjCMethodTest >> test_getDescription [
+	| method |
+	method := #NSObject inObjC copyMethodList detect: [ :e | e getName name = 'isEqualTo:' ].
+	self assert: (method getDescription).
+]
+
+{ #category : #tests }
+ObjCMethodTest >> test_getImplementation [
+	| method |
+	method := #NSObject inObjC copyMethodList detect: [ :e | e getName name = 'isEqualTo:' ].
+	self assert: (method getImplementation isKindOf: ObjCMethodImplementation).
+]
+
+{ #category : #tests }
+ObjCMethodTest >> test_getName [
+	| method |
+	method := #NSObject inObjC copyMethodList detect: [ :e | e getName name = 'isEqualTo:' ].
+	self assert: (method getName isKindOf: ObjCSelector).
+]
+
+{ #category : #tests }
+ObjCMethodTest >> test_getReturnType [
+	| method |
+	method := #NSObject inObjC copyMethodList detect: [ :e | e getName name = 'isEqualTo:' ].
+	self assert: method getReturnType equals: 'c'.
+]
+
+{ #category : #tests }
+ObjCMethodTest >> test_getTypeEncoding [
+	| method |
+	method := #NSObject inObjC copyMethodList detect: [ :e | e getName name = 'isEqualTo:' ].
+	self assert: method getTypeEncoding equals: 'c24@0:8@16'.
+]
+
+{ #category : #tests }
+ObjCMethodTest >> test_numArgs [
+	| method |
+	self assert: false.
+	method := #NSObject inObjC copyMethodList detect: [ :e | e getName name = 'isEqualTo:' ].
+	self assert: method returnType equals: 'c'.
+]
+
+{ #category : #tests }
+ObjCMethodTest >> test_returnType [
+	| method |
+	method := #NSObject inObjC copyMethodList detect: [ :e | e getName name = 'isEqualTo:' ].
+	self assert: method returnType equals: 'c'.
+]

--- a/src/ObjectiveC-Tests/ObjCObjectTest.class.st
+++ b/src/ObjectiveC-Tests/ObjCObjectTest.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #ObjCObjectTest,
+	#superclass : #TestCase,
+	#category : #'ObjectiveC-Tests-Core'
+}
+
+{ #category : #tests }
+ObjCObjectTest >> test_getClass [
+	| object |
+	object := #NSObject inObjC alloc init autorelease.
+	self assert: object getClass name equals: 'NSObject'.
+]
+
+{ #category : #tests }
+ObjCObjectTest >> test_getClassName [
+	| object |
+	object := #NSObject inObjC alloc init autorelease.
+	self assert: object getClassName equals: 'NSObject'.
+]

--- a/src/ObjectiveC-Tests/ObjCProtocolTest.class.st
+++ b/src/ObjectiveC-Tests/ObjCProtocolTest.class.st
@@ -1,0 +1,22 @@
+Class {
+	#name : #ObjCProtocolTest,
+	#superclass : #TestCase,
+	#category : #'ObjectiveC-Tests-Core'
+}
+
+{ #category : #tests }
+ObjCProtocolTest >> test_getName [
+	| protocol |
+	protocol := ObjCProtocol getProtocol: 'NSObject'.
+	self assert: protocol getName equals: 'NSObject'
+]
+
+{ #category : #tests }
+ObjCProtocolTest >> test_getProtocol [
+	| protocol |
+	protocol := ObjCProtocol getProtocol: 'nonexistent'.
+	self assert: protocol isNull.
+	
+	protocol := ObjCProtocol getProtocol: 'NSObject'.
+	self deny: protocol isNull.
+]

--- a/src/ObjectiveC-Tests/ObjCSpecParserTest.class.st
+++ b/src/ObjectiveC-Tests/ObjCSpecParserTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'parser'
 	],
-	#category : #ObjectiveC-Tests
+	#category : #'ObjectiveC-Tests'
 }
 
 { #category : #accessing }

--- a/src/ObjectiveC-Tests/ObjCStringTest.class.st
+++ b/src/ObjectiveC-Tests/ObjCStringTest.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #ObjCStringTest,
+	#superclass : #TestCase,
+	#category : #'ObjectiveC-Tests'
+}
+
+{ #category : #tests }
+ObjCStringTest >> testAsFourCharCode [
+
+	self assert: 'pTrk' asObjCFourCharCode equals: 1884582507.
+]

--- a/src/ObjectiveC-Tests/package.st
+++ b/src/ObjectiveC-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #ObjectiveC-Tests }
+Package { #name : #'ObjectiveC-Tests' }

--- a/src/ObjectiveC/ManifestObjectiveC.class.st
+++ b/src/ObjectiveC/ManifestObjectiveC.class.st
@@ -1,0 +1,8 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
+Class {
+	#name : #ManifestObjectiveC,
+	#superclass : #PackageManifest,
+	#category : #'ObjectiveC-Manifest'
+}

--- a/src/ObjectiveC/ObjCClass.class.st
+++ b/src/ObjectiveC/ObjCClass.class.st
@@ -100,26 +100,16 @@ ObjCClass >> classMethodAt: aSelector put: aMethod [
 { #category : #'objective-c run-time' }
 ObjCClass >> conformsToProtocol: protocol [
 	"https://developer.apple.com/documentation/objectivec/1418685-class_conformstoprotocol?language=objc"
-	^ self ffiCall: #(BOOL class_conformsToProtocol(self, Protocol *protocol))
-]
-
-{ #category : #'objective-c run-time' }
-ObjCClass >> convertPointerArrayReturnedBy: selector toInstances: aClass [
-	| outCount result pointers |
-	outCount := FFIUInt32 newBuffer.
-	result := self perform: selector with: outCount.
-	result getHandle isNull ifTrue: [ ^ Array new ].
-	pointers := result getHandle readArrayOf: FFIOop new until: [ :e | e isNull ].
-	result getHandle free.
-	^ pointers collect: [ :e | aClass fromHandle: e ].
+	^ self ffiCall: #(BOOL class_conformsToProtocol(Class self, Protocol *protocol))
 ]
 
 { #category : #'objective-c run-time' }
 ObjCClass >> copyIvarList [
-	^ self convertPointerArrayReturnedBy: #copyIvarList: toInstances: ObjCInstanceVariable
+	"https://developer.apple.com/documentation/objectivec/1418910-class_copyivarlist?language=objc"
+	^ self returnArrayFrom: #copyIvarList: AsInstancesOf: ObjCInstanceVariable
 ]
 
-{ #category : #'objective-c run-time' }
+{ #category : #private }
 ObjCClass >> copyIvarList: outCount [
 	"https://developer.apple.com/documentation/objectivec/1418910-class_copyivarlist?language=objc"
 	^ self ffiCall: #(Ivar* class_copyIvarList(Class self, uint *outCount))
@@ -127,10 +117,11 @@ ObjCClass >> copyIvarList: outCount [
 
 { #category : #'objective-c run-time' }
 ObjCClass >> copyMethodList [
-	^ self convertPointerArrayReturnedBy: #copyMethodList: toInstances: ObjCMethod
+	"https://developer.apple.com/documentation/objectivec/1418490-class_copymethodlist?language=objc"
+	^ self returnArrayFrom: #copyMethodList: AsInstancesOf: ObjCMethod
 ]
 
-{ #category : #'objective-c run-time' }
+{ #category : #private }
 ObjCClass >> copyMethodList: outCount [
 	"https://developer.apple.com/documentation/objectivec/1418490-class_copymethodlist?language=objc"
 	^ self ffiCall: #(Method * class_copyMethodList(Class self, uint *outCount))
@@ -138,10 +129,11 @@ ObjCClass >> copyMethodList: outCount [
 
 { #category : #'objective-c run-time' }
 ObjCClass >> copyPropertyList [
-	^ self convertPointerArrayReturnedBy: #copyPropertyList: toInstances: ObjCProperty
+	"https://developer.apple.com/documentation/objectivec/1418553-class_copypropertylist?language=objc"
+	^ self returnArrayFrom: #copyPropertyList: AsInstancesOf: ObjCProperty
 ]
 
-{ #category : #'objective-c run-time' }
+{ #category : #private }
 ObjCClass >> copyPropertyList: outCount [
 	"https://developer.apple.com/documentation/objectivec/1418553-class_copypropertylist?language=objc"
 
@@ -150,10 +142,11 @@ ObjCClass >> copyPropertyList: outCount [
 
 { #category : #'objective-c run-time' }
 ObjCClass >> copyProtocolList [
-	^ self convertPointerArrayReturnedBy: #copyProtocolList: toInstances: ObjCProtocol
+	"https://developer.apple.com/documentation/objectivec/1418883-class_copyprotocollist?language=objc"
+	^ self returnArrayFrom: #copyProtocolList: AsInstancesOf: ObjCProtocol
 ]
 
-{ #category : #'objective-c run-time' }
+{ #category : #private }
 ObjCClass >> copyProtocolList: outCount [
 	"https://developer.apple.com/documentation/objectivec/1418883-class_copyprotocollist?language=objc"
 	^ self ffiCall: #(Protocol ** class_copyProtocolList(Class self, uint *outCount))
@@ -162,7 +155,7 @@ ObjCClass >> copyProtocolList: outCount [
 { #category : #'objective-c run-time' }
 ObjCClass >> getClassMethod: name [
 	"https://developer.apple.com/documentation/objectivec/1418887-class_getclassmethod?language=objc"
-	^ self ffiCall: #(Method class_getClassMethod(self, SEL name))
+	^ self ffiCall: #(Method class_getClassMethod(Class self, SEL name))
 ]
 
 { #category : #'objective-c run-time' }
@@ -178,9 +171,15 @@ ObjCClass >> getFutureClass [
 ]
 
 { #category : #'objective-c run-time' }
+ObjCClass >> getImageName [
+	"https://developer.apple.com/documentation/objectivec/1418539-class_getimagename?language=objc"
+	^ self ffiCall: #(const char * class_getImageName(Class self))
+]
+
+{ #category : #'objective-c run-time' }
 ObjCClass >> getInstanceMethod: aName [
 	"https://developer.apple.com/documentation/objectivec/1418530-class_getinstancemethod?language=objc"
-	^ self ffiCall: #(Method class_getInstanceMethod(self, SEL aName))
+	^ self ffiCall: #(Method class_getInstanceMethod(Class self, SEL aName))
 ]
 
 { #category : #'objective-c run-time' }
@@ -237,6 +236,24 @@ ObjCClass >> getVersion [
 ObjCClass >> getWeakIvarLayout [
 	"https://developer.apple.com/documentation/objectivec/1418918-class_getivarlayout?language=objc"
 	^ self ffiCall: #(const uint8_t * class_getWeakIvarLayout(self))
+]
+
+{ #category : #inspecting }
+ObjCClass >> gtInspectorRuntimeFields [
+
+	^ super gtInspectorRuntimeFields, { 
+			'Name' -> self getName.
+			'Inst Vars' -> (self copyIvarList sorted: [ :a :b | a getName < b getName ]).
+			'Messages' -> (self copyMethodList sorted: [ :a :b | a selector name < b selector name ]).
+			'Metaclass?' -> self isMetaClass.
+			'Properties' -> self copyPropertyList.
+			'Protocols' -> self copyProtocolList.
+			'Instance Size' -> self getInstanceSize.
+			'Inst Var Layout' -> self getIvarLayout.
+			'Superclass' -> self getSuperclass.
+			'Version' -> self getVersion.
+			'Weak Inst Var Layout' -> self getWeakIvarLayout.
+			'Image Name' -> self getImageName }
 ]
 
 { #category : #initialization }
@@ -323,11 +340,23 @@ ObjCClass >> replaceProperty [
 ]
 
 { #category : #'objective-c run-time' }
-ObjCClass >> respondsToSelector: aSymbol [
-	"https://developer.apple.com/documentation/objectivec/1418517-class_respondstoselector?language=objc"
-	self flag: 'Any way to prepare args like so?: 
-		sel := aSymbol asObjCSelector'.
-	^ self ffiCall: #(BOOL class_respondsToSelector(self, SEL aSymbol))
+ObjCClass >> respondsToSelector: anObjCSelector [
+	"
+	anObjCSelector - can be obtained from aSymbol `aSymbol asObjCSelector`
+	
+	Documentation: https://developer.apple.com/documentation/objectivec/1418517-class_respondstoselector?language=objc"
+	^ self ffiCall: #(BOOL class_respondsToSelector(Class self, SEL anObjCSelector))
+]
+
+{ #category : #private }
+ObjCClass >> returnArrayFrom: selector AsInstancesOf: aClass [
+	| outCount result pointers |
+	outCount := FFIUInt32 newBuffer.
+	result := self perform: selector with: outCount.
+	result getHandle isNull ifTrue: [ ^ Array new ].
+	pointers := result getHandle readArrayOf: FFIOop new until: [ :e | e isNull ].
+	result getHandle free.
+	^ pointers collect: [ :e | aClass fromHandle: e ].
 ]
 
 { #category : #'objective-c run-time' }

--- a/src/ObjectiveC/ObjCClass.class.st
+++ b/src/ObjectiveC/ObjCClass.class.st
@@ -45,6 +45,32 @@ ObjCClass class >> lookup: globalOrClassName inLibrary: libraryName [
 	^ self lookup: globalOrClassName
 ]
 
+{ #category : #'objective-c run-time' }
+ObjCClass class >> objc_getClassList [
+	"https://developer.apple.com/documentation/objectivec/1418579-objc_getclasslist?language=objc"
+	^ self ffiCall: #(int objc_getClassList(Class *buffer, int bufferCount))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> addIvar [
+	self shouldBeImplemented.
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> addMethod [
+	self shouldBeImplemented 
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> addProperty [
+	self shouldBeImplemented.
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> addProtocol [
+	self shouldBeImplemented.
+]
+
 { #category : #accessing }
 ObjCClass >> classMethodAt: aSelector [
 	^ classMethods 
@@ -71,9 +97,117 @@ ObjCClass >> classMethodAt: aSelector put: aMethod [
 	^ classMethods at: aSelector put: aMethod
 ]
 
-{ #category : #private }
-ObjCClass >> class_getClassMethod: aName [
-	^ self ffiCall: #(Method class_getClassMethod(self, SEL aName))
+{ #category : #'objective-c run-time' }
+ObjCClass >> conformsToProtocol: protocol [
+	"https://developer.apple.com/documentation/objectivec/1418685-class_conformstoprotocol?language=objc"
+	^ self ffiCall: #(BOOL class_conformsToProtocol(self, Protocol *protocol))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> copyIvarList [
+	"https://developer.apple.com/documentation/objectivec/1418910-class_copyivarlist?language=objc"
+	self flag: 'How to pass int address?'.
+	^ self ffiCall: #(Ivar* class_copyIvarList(self, unsigned int *outCount))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> copyMethodList [
+	"https://developer.apple.com/documentation/objectivec/1418490-class_copymethodlist?language=objc"
+	^ self ffiCall: #(Method * class_copyMethodList(self, unsigned int *outCount))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> copyPropertyList [
+	"https://developer.apple.com/documentation/objectivec/1418553-class_copypropertylist?language=objc"
+
+	^ self ffiCall: #(objc_property_t * class_copyPropertyList(Class cls, unsigned int *outCount))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> copyProtocolList [
+	"https://developer.apple.com/documentation/objectivec/1418883-class_copyprotocollist?language=objc"
+	self flag: 'How to pass int address?'.
+	^ self ffiCall: #(Protocol ** class_copyProtocolList(self, unsigned int *outCount))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getClassMethod: name [
+	"https://developer.apple.com/documentation/objectivec/1418887-class_getclassmethod?language=objc"
+	^ self ffiCall: #(Method class_getClassMethod(self, SEL name))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getClassVariable: name [
+	"https://developer.apple.com/documentation/objectivec/1418487-class_getclassvariable?language=objc"
+
+	^ self ffiCall: #(#Ivar #class_getClassVariable #(#self #, #const #char #* #name))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getFutureClass [
+	self shouldBeImplemented.
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getInstanceMethod: aName [
+	"https://developer.apple.com/documentation/objectivec/1418530-class_getinstancemethod?language=objc"
+	^ self ffiCall: #(Method class_getInstanceMethod(self, SEL aName))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getInstanceSize [
+	"https://developer.apple.com/documentation/objectivec/1418907-class_getinstancesize?language=objc"
+	^ self ffiCall: #(size_t class_getInstanceSize(self))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getInstanceVariable: name [
+	"https://developer.apple.com/documentation/objectivec/1418643-class_getinstancevariable?language=objc"
+	^ self ffiCall: #(Ivar class_getInstanceVariable(self, const char *name))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getIvarLayout [
+	"https://developer.apple.com/documentation/objectivec/1418918-class_getivarlayout?language=objc"
+	^ self ffiCall: #(uint8_t * class_getIvarLayout(self))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getMethodImplementation: name [
+	"https://developer.apple.com/documentation/objectivec/1418811-class_getmethodimplementation?language=objc"
+	self flag: 'How does this differ from class_getMethodImplementation_stret?'.
+	^ self ffiCall: #(IMP class_getMethodImplementation(self, SEL name))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getName [
+	"https://developer.apple.com/documentation/objectivec/1418635-class_getname?language=objc"
+	^ self ffiCall: #(char * class_getName(self))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getProperty: name [
+	"Seems to walk up the inheritance chain and return props of superclasses, too
+	https://developer.apple.com/documentation/objectivec/1418597-class_getproperty?language=objc"
+	^ self ffiCall: #(objc_property_t class_getProperty(self, const char *name))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getSuperclass [
+	"You should usually use NSObject‘s superclass method instead of this function per documentation: https://developer.apple.com/documentation/objectivec/1418498-class_getsuperclass?language=objc"
+	^ self ffiCall: #(Class class_getSuperclass(self))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getVersion [
+	"https://developer.apple.com/documentation/objectivec/1418537-class_getversion?language=objc"
+	^ self ffiCall: #(int class_getVersion(self))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> getWeakIvarLayout [
+	"https://developer.apple.com/documentation/objectivec/1418918-class_getivarlayout?language=objc"
+	^ self ffiCall: #(const uint8_t * class_getWeakIvarLayout(self))
 ]
 
 { #category : #initialization }
@@ -100,6 +234,12 @@ ObjCClass >> installedMethodAt: aSelector [
 	^ self 
 		classMethodAt: aSelector 
 		ifAbsent: [ nil ]
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> isMetaClass [
+	"https://developer.apple.com/documentation/objectivec/1418627-class_ismetaclass?language=objc"
+	^ self ffiCall: #(BOOL class_isMetaClass(self))
 ]
 
 { #category : #accessing }
@@ -130,15 +270,53 @@ ObjCClass >> methodAt: aSelector put: aMethod [
 
 { #category : #accessing }
 ObjCClass >> name [
-	^ self ffiCall: #(char * class_getName(self))
+	^ self getName
 ]
 
 { #category : #private }
 ObjCClass >> objCMethodForSelector: aSelector [
-	^ self class_getClassMethod: aSelector asObjCSelector
+	^ self getClassMethod: aSelector asObjCSelector
 ]
 
 { #category : #printing }
 ObjCClass >> printOn: aStream [ 
 	aStream << 'ObjC:' << self name
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> replaceMethod [
+	self shouldBeImplemented 
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> replaceProperty [
+	self shouldBeImplemented.
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> respondsToSelector: aSymbol [
+	"https://developer.apple.com/documentation/objectivec/1418517-class_respondstoselector?language=objc"
+	self flag: 'Any way to prepare args like so?: 
+		sel := aSymbol asObjCSelector'.
+	^ self ffiCall: #(BOOL class_respondsToSelector(self, SEL aSymbol))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> setFutureClass [
+	self shouldBeImplemented.
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> setIvarLayout [
+	self shouldBeImplemented.
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> setVersion [
+	self shouldBeImplemented.
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> setWeakIvarLayout [
+	self shouldBeImplemented 
 ]

--- a/src/ObjectiveC/ObjCClass.class.st
+++ b/src/ObjectiveC/ObjCClass.class.st
@@ -104,30 +104,59 @@ ObjCClass >> conformsToProtocol: protocol [
 ]
 
 { #category : #'objective-c run-time' }
+ObjCClass >> convertPointerArrayReturnedBy: selector toInstances: aClass [
+	| outCount result pointers |
+	outCount := FFIUInt32 newBuffer.
+	result := self perform: selector with: outCount.
+	result getHandle isNull ifTrue: [ ^ Array new ].
+	pointers := result getHandle readArrayOf: FFIOop new until: [ :e | e isNull ].
+	result getHandle free.
+	^ pointers collect: [ :e | aClass fromHandle: e ].
+]
+
+{ #category : #'objective-c run-time' }
 ObjCClass >> copyIvarList [
+	^ self convertPointerArrayReturnedBy: #copyIvarList: toInstances: ObjCInstanceVariable
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> copyIvarList: outCount [
 	"https://developer.apple.com/documentation/objectivec/1418910-class_copyivarlist?language=objc"
-	self flag: 'How to pass int address?'.
-	^ self ffiCall: #(Ivar* class_copyIvarList(self, unsigned int *outCount))
+	^ self ffiCall: #(Ivar* class_copyIvarList(Class self, uint *outCount))
 ]
 
 { #category : #'objective-c run-time' }
 ObjCClass >> copyMethodList [
+	^ self convertPointerArrayReturnedBy: #copyMethodList: toInstances: ObjCMethod
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> copyMethodList: outCount [
 	"https://developer.apple.com/documentation/objectivec/1418490-class_copymethodlist?language=objc"
-	^ self ffiCall: #(Method * class_copyMethodList(self, unsigned int *outCount))
+	^ self ffiCall: #(Method * class_copyMethodList(Class self, uint *outCount))
 ]
 
 { #category : #'objective-c run-time' }
 ObjCClass >> copyPropertyList [
+	^ self convertPointerArrayReturnedBy: #copyPropertyList: toInstances: ObjCProperty
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> copyPropertyList: outCount [
 	"https://developer.apple.com/documentation/objectivec/1418553-class_copypropertylist?language=objc"
 
-	^ self ffiCall: #(objc_property_t * class_copyPropertyList(Class cls, unsigned int *outCount))
+	^ self ffiCall: #(objc_property_t * class_copyPropertyList(Class self, uint *outCount))
 ]
 
 { #category : #'objective-c run-time' }
 ObjCClass >> copyProtocolList [
+	^ self convertPointerArrayReturnedBy: #copyProtocolList: toInstances: ObjCProtocol
+]
+
+{ #category : #'objective-c run-time' }
+ObjCClass >> copyProtocolList: outCount [
 	"https://developer.apple.com/documentation/objectivec/1418883-class_copyprotocollist?language=objc"
-	self flag: 'How to pass int address?'.
-	^ self ffiCall: #(Protocol ** class_copyProtocolList(self, unsigned int *outCount))
+	^ self ffiCall: #(Protocol ** class_copyProtocolList(Class self, uint *outCount))
 ]
 
 { #category : #'objective-c run-time' }

--- a/src/ObjectiveC/ObjCExamples.class.st
+++ b/src/ObjectiveC/ObjCExamples.class.st
@@ -4,7 +4,38 @@ Class {
 	#category : #'ObjectiveC-Examples'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #examples }
+ObjCExamples class >> exampleAppleScriptFromFile [
+
+	| source scriptFile path pathURL err scpt |
+	source := 'tell application "Finder" to display alert "Hello World"'.
+	scriptFile := FileReference newTempFilePrefix: '' suffix: '.scpt'.
+	scriptFile writeStreamDo: [ :str | str nextPutAll: source ].
+	path := scriptFile fullName asNSString autorelease.
+	pathURL := #NSURL inObjC fileURLWithPath: path.
+	err := #NSDictionary inObjC dictionary.
+	err pin.
+	scpt := #NSAppleScript inObjC alloc
+		initWithContentsOfURL: pathURL
+		error: err.
+	scpt executeAndReturnError: err.
+	err unpin.
+	scriptFile delete.
+]
+
+{ #category : #examples }
+ObjCExamples class >> exampleAppleScriptFromString [
+
+	| source err scpt |
+	source := 'tell application "Safari" to display alert "Hello World"'.
+	err := #NSDictionary inObjC dictionary.
+	scpt := #NSAppleScript inObjC alloc initWithSource: source asNSString autorelease.
+	err pin.
+	scpt executeAndReturnError: err.
+	err unpin
+]
+
+{ #category : #examples }
 ObjCExamples class >> exampleScriptingBridge [
 	| iTunesID iTunes |
 	DynamicLoader loadLibrary: '/System/Library/Frameworks/ScriptingBridge.framework/ScriptingBridge'.

--- a/src/ObjectiveC/ObjCExamples.class.st
+++ b/src/ObjectiveC/ObjCExamples.class.st
@@ -36,6 +36,63 @@ ObjCExamples class >> exampleAppleScriptFromString [
 ]
 
 { #category : #examples }
+ObjCExamples class >> exampleAppleScriptHandlerWithArguments [
+	<sampleInstance>
+	"Adapted from http://appscript.sourceforge.net/nsapplescript.html"
+	
+	| kASAppleScriptSuite kASSubroutineEvent keyASSubroutineName kAutoGenerateReturnID kAnyTransactionID keyDirectObject params arg1 arg2 handlerName handlerDesc source script targetDescriptor event errInfo resultDesc |
+	
+	self flag: 'NOT CAREFUL WITH MEMORY MANAGEMENT. MAY BE LEAKY'.
+	
+	"Carbon constants (via https://lists.apple.com/archives/cocoa-dev/2007/Sep/msg01294.html)"
+	kASAppleScriptSuite := 'ascr' asObjCFourCharCode.
+	kASSubroutineEvent := 'psbr' asObjCFourCharCode.
+	keyASSubroutineName := 'snam' asObjCFourCharCode.
+	
+	"Cocoa constants"
+	kAutoGenerateReturnID := -1.	"AECreateAppleEvent will generate a session-unique ID"
+	kAnyTransactionID := 0. "no transaction is in use"
+	keyDirectObject := '----' asObjCFourCharCode.
+	
+	"AE Description of arguments"
+	params := #NSAppleEventDescriptor inObjC listDescriptor.
+	arg1 := #NSAppleEventDescriptor inObjC descriptorWithInt32: 2.
+	params insertDescriptor: arg1 atIndex: 1.
+	arg2 := #NSAppleEventDescriptor inObjC descriptorWithInt32: 6.
+	params insertDescriptor: arg2 atIndex: 2.
+	
+	"AE Description of handler"
+	handlerName := 'addTo' asNSString autorelease.
+	handlerDesc := #NSAppleEventDescriptor inObjC
+		descriptorWithString: handlerName.
+		
+	"Script"
+	source := ' on addTo(a, b)
+	return a + b
+end addTo ' asNSString autorelease.
+	script := #NSAppleScript inObjC alloc autorelease initWithSource: source.
+
+	"Finally assemble full Apple Event to send"
+	targetDescriptor := #NSAppleEventDescriptor inObjC nullDescriptor.
+	event := #NSAppleEventDescriptor inObjC
+		appleEventWithEventClass: kASAppleScriptSuite
+		eventID: kASSubroutineEvent
+		targetDescriptor: targetDescriptor
+		returnID: kAutoGenerateReturnID
+		transactionID: kAnyTransactionID.
+	event setDescriptor: params forKeyword: keyDirectObject.
+	event setDescriptor: handlerDesc forKeyword: keyASSubroutineName.
+	
+	"Send event to script"
+	errInfo := #NSDictionary inObjC dictionary.
+	errInfo pin.
+	resultDesc := script executeAppleEvent: event error: errInfo.
+	errInfo unpin.
+	
+	^ resultDesc int32Value
+]
+
+{ #category : #examples }
 ObjCExamples class >> exampleScriptingBridge [
 	| iTunesID iTunes |
 	DynamicLoader loadLibrary: '/System/Library/Frameworks/ScriptingBridge.framework/ScriptingBridge'.

--- a/src/ObjectiveC/ObjCExamples.class.st
+++ b/src/ObjectiveC/ObjCExamples.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #ObjCExamples,
+	#superclass : #Object,
+	#category : #'ObjectiveC-Examples'
+}
+
+{ #category : #'as yet unclassified' }
+ObjCExamples class >> exampleScriptingBridge [
+	| iTunesID iTunes |
+	DynamicLoader loadLibrary: '/System/Library/Frameworks/ScriptingBridge.framework/ScriptingBridge'.
+	iTunesID := 'com.apple.iTunes' asNSString autorelease.
+	iTunes := (#SBApplication inObjCFramework: 'ScriptingBridge')
+		applicationWithBundleIdentifier: iTunesID.
+	^ iTunes activate
+]

--- a/src/ObjectiveC/ObjCImage.class.st
+++ b/src/ObjectiveC/ObjCImage.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #ObjCImage,
+	#superclass : #Object,
+	#instVars : [
+		'macLibraryFile'
+	],
+	#category : #'ObjectiveC-Core'
+}
+
+{ #category : #'instance creation' }
+ObjCImage class >> named: aString [
+	^ self new
+			macLibraryFile: aString asFileReference;
+			yourself
+]
+
+{ #category : #accessing }
+ObjCImage >> macLibraryFile [
+	^ macLibraryFile
+]
+
+{ #category : #accessing }
+ObjCImage >> macLibraryFile: anObject [
+	macLibraryFile := anObject
+]

--- a/src/ObjectiveC/ObjCInstanceVariable.class.st
+++ b/src/ObjectiveC/ObjCInstanceVariable.class.st
@@ -1,0 +1,28 @@
+"
+I represent the Objective-C Runtime's Ivar data type. See documention at https://developer.apple.com/documentation/objectivec/ivar?language=objc
+"
+Class {
+	#name : #ObjCInstanceVariable,
+	#superclass : #FFIExternalObject,
+	#traits : 'TObjCLibrary',
+	#classTraits : 'TObjCLibrary classTrait',
+	#category : #'ObjectiveC-Core'
+}
+
+{ #category : #accessing }
+ObjCInstanceVariable >> getName [
+	"https://developer.apple.com/documentation/objectivec/1418903-property_getname?language=objc"
+	^ self ffiCall: #(const char * ivar_getName(self))
+]
+
+{ #category : #accessing }
+ObjCInstanceVariable >> getOffset [
+	"https://developer.apple.com/documentation/objectivec/1418976-ivar_getoffset?language=objc"
+	^ self ffiCall: #(ptrdiff_t ivar_getOffset(self))
+]
+
+{ #category : #accessing }
+ObjCInstanceVariable >> getTypeEncoding [
+	"https://developer.apple.com/documentation/objectivec/1418569-ivar_gettypeencoding?language=objc"
+	^ self ffiCall: #(const char * ivar_getTypeEncoding(self))
+]

--- a/src/ObjectiveC/ObjCInstanceVariable.class.st
+++ b/src/ObjectiveC/ObjCInstanceVariable.class.st
@@ -9,20 +9,55 @@ Class {
 	#category : #'ObjectiveC-Core'
 }
 
-{ #category : #accessing }
-ObjCInstanceVariable >> getName [
-	"https://developer.apple.com/documentation/objectivec/1418903-property_getname?language=objc"
-	^ self ffiCall: #(const char * ivar_getName(self))
+{ #category : #displaying }
+ObjCInstanceVariable >> displayString [
+	^ self getName
 ]
 
-{ #category : #accessing }
+{ #category : #'objective-c run-time' }
+ObjCInstanceVariable >> getName [
+	"https://developer.apple.com/documentation/objectivec/1418922-ivar_getname?language=objc"
+	^ self ffiCall: #(const char * ivar_getName(Ivar self))
+]
+
+{ #category : #'objective-c run-time' }
 ObjCInstanceVariable >> getOffset [
 	"https://developer.apple.com/documentation/objectivec/1418976-ivar_getoffset?language=objc"
-	^ self ffiCall: #(ptrdiff_t ivar_getOffset(self))
+	^ self ffiCall: #(ptrdiff_t ivar_getOffset(Ivar self))
 ]
 
-{ #category : #accessing }
+{ #category : #'objective-c run-time' }
 ObjCInstanceVariable >> getTypeEncoding [
 	"https://developer.apple.com/documentation/objectivec/1418569-ivar_gettypeencoding?language=objc"
-	^ self ffiCall: #(const char * ivar_getTypeEncoding(self))
+	^ self ffiCall: #(const char * ivar_getTypeEncoding(Ivar self))
+]
+
+{ #category : #inspecting }
+ObjCInstanceVariable >> gtInspectorRuntimeIn: composite [
+	<gtInspectorPresentationOrder: 10>
+	composite fastTreeTable
+		title: 'Runtime (ObjC)';
+		hasChildren: [ :e | e value isArray and: [ e isKindOf: Association ] ];
+		display: [ { 
+			'Name' -> self getName.
+			'Offset' -> self getOffset.
+			'Type Encoding' -> self getTypeEncoding } ];
+		column: 'Field' translated evaluated: [  :e | (e isKindOf: Association) ifTrue: [ e key ] ifFalse: [ e displayString ] ];
+		column: 'Value' translated evaluated: [  :e | 
+			e value isArray 
+				ifTrue: [ e value size asString, ' items' ] 
+				ifFalse: [ 
+					((e value respondsTo: #isNull) and: [ e value isNull ]) 
+						ifTrue: [ 'null' ] 
+						ifFalse: [ e value ] ] ];
+		children: [ :e | e value ];
+		send: #value
+]
+
+{ #category : #printing }
+ObjCInstanceVariable >> printOn: aStream [
+	super printOn: aStream.
+	aStream 
+		space;
+		nextPutAll: self getName
 ]

--- a/src/ObjectiveC/ObjCLibrary.class.st
+++ b/src/ObjectiveC/ObjCLibrary.class.st
@@ -4,6 +4,8 @@ I point to libobjc and I provide mapping to it's types.
 Class {
 	#name : #ObjCLibrary,
 	#superclass : #FFILibrary,
+	#traits : 'TObjCInspectable',
+	#classTraits : 'TObjCInspectable classTrait',
 	#instVars : [
 		'runner',
 		'session'
@@ -22,14 +24,25 @@ ObjCLibrary class >> createObjCTypes [
 		Class 					ObjCClass
 		id 						ObjCObject
 		Ivar 					ObjCInstanceVariable
+							
+		"https://developer.apple.com/documentation/objectivec/objective-c_runtime/imp?language=objc"
 		IMP 					ObjCProxyCallback
 		Method 				ObjCMethod
 		objc_property_t 	ObjCProperty
 		Protocol 				ObjCProtocol
-		ptrdiff_t 			long "typedef for __darwin_ptrdiff_t, a long on 64-bit (see _types.h)"
+		
+		"typedef for __darwin_ptrdiff_t, a long on MacOS 64-bit (see _types.h)"				
+		ptrdiff_t 			long
 		SEL 					ObjCSelector
-		uint8_t 				uchar "Drill down from https://developer.apple.com/documentation/kernel/uint8_t?language=objc"
+							
+		"Drill down from https://developer.apple.com/documentation/kernel/uint8_t?language=objc"
+		uint8_t 				uchar
 	)
+]
+
+{ #category : #'encoding types' }
+ObjCLibrary class >> decodeType: aString [
+	^ self typeEncodings at: aString ifAbsent: [ '?' ]
 ]
 
 { #category : #private }
@@ -60,15 +73,90 @@ ObjCLibrary class >> initializeObjCTypes [
 	ObjCTypes := self createObjCTypes
 ]
 
+{ #category : #'encoding types' }
+ObjCLibrary class >> typeEncodings [
+	"See https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100"
+	^ Dictionary newFromPairs: #( 
+			c char
+			i int
+			s short
+			l long "l is treated as a 32-bit quantity on 64-bit programs."
+			q 'long long'
+			C 'unsigned char'
+			I 'unsigned int'
+			S 'unsigned short'
+			L 'unsigned long'
+			Q 'unsigned long long'
+			f float
+			d double
+			B 'C++ bool or a C99 _Bool'
+			v void
+			* 'character string (char *)'
+			@ 'object (whether statically typed or typed id)'
+			'#' 'class object (Class)'
+			: 'method selector (SEL)'
+			? 'unknown type') "(among other things, this code is used for function pointers)"
+]
+
 { #category : #converting }
 ObjCLibrary >> calloutAPIClass [ 
 
 	^ TFCalloutAPI
 ]
 
+{ #category : #'objective-c run-time' }
+ObjCLibrary >> copyClassNamesForImage: pathString [
+	| outCount names result |
+	outCount := FFIUInt32 newBuffer.
+	names := self copyClassNamesForImage: pathString outCount: outCount.
+	result := [ names getHandle isNull
+		ifTrue: [ ^ Array new ].
+	names getHandle
+		readArrayOf: FFIExternalString new
+		until: [ :e | e isNil ] ]
+		ensure: [ names getHandle free ].
+	^ result
+]
+
+{ #category : #'objective-c run-time' }
+ObjCLibrary >> copyClassNamesForImage: pathString outCount: outCount [
+	"https://developer.apple.com/documentation/objectivec/1418970-objc_copyimagenames?language=objc"
+	^ self ffiCall: #(const char ** objc_copyClassNamesForImage(const char *pathString, uint *outCount))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCLibrary >> copyImageNames [
+	| outCount names result |
+	outCount := FFIUInt32 newBuffer.
+	names := self copyImageNames: outCount.
+	result := [ names getHandle isNull
+		ifTrue: [ ^ Array new ].
+	names getHandle
+		readArrayOf: FFIExternalString new
+		until: [ :e | e isNil ] ]
+		ensure: [ names getHandle free ].
+	^ result
+]
+
+{ #category : #'objective-c run-time' }
+ObjCLibrary >> copyImageNames: outCount [
+	"https://developer.apple.com/documentation/objectivec/1418970-objc_copyimagenames?language=objc"
+	^ self ffiCall: #(const char ** objc_copyImageNames(uint *outCount))
+]
+
 { #category : #'accessing platform' }
 ObjCLibrary >> ffiBindingOf: aName [
 	^ self class ffiBindingOf: aName
+]
+
+{ #category : #inspecting }
+ObjCLibrary >> gtInspectorRuntimeIn: composite [
+	<gtInspectorPresentationOrder: 10>
+	
+	self 
+		gtInspectorObjCRuntimeFields: { 
+			'Image Names' -> self copyImageNames }
+		in: composite
 ]
 
 { #category : #'accessing platform' }

--- a/src/ObjectiveC/ObjCLibrary.class.st
+++ b/src/ObjectiveC/ObjCLibrary.class.st
@@ -159,6 +159,11 @@ ObjCLibrary >> gtInspectorRuntimeIn: composite [
 		in: composite
 ]
 
+{ #category : #'objective-c run-time' }
+ObjCLibrary >> images [
+	^ self copyImageNames collect: [ :e | ObjCImage named: e ]
+]
+
 { #category : #'accessing platform' }
 ObjCLibrary >> macLibraryName [
 	^ 'libobjc.dylib'

--- a/src/ObjectiveC/ObjCLibrary.class.st
+++ b/src/ObjectiveC/ObjCLibrary.class.st
@@ -17,13 +17,18 @@ Class {
 { #category : #private }
 ObjCLibrary class >> createObjCTypes [
 	^ Dictionary newFromPairs: #(
-		Method 	ObjCMethod
-		Class 		ObjCClass
-		SEL 		ObjCSelector
-		id 			ObjCObject
-		IMP 		ObjCProxyCallback
-		BOOL 		bool
-		CGFloat 	double "float in 32bits"
+		BOOL 					bool
+		CGFloat 				double "float in 32bits"
+		Class 					ObjCClass
+		id 						ObjCObject
+		Ivar 					ObjCInstanceVariable
+		IMP 					ObjCProxyCallback
+		Method 				ObjCMethod
+		objc_property_t 	ObjCProperty
+		Protocol 				ObjCProtocol
+		ptrdiff_t 			long "typedef for __darwin_ptrdiff_t, a long on 64-bit (see _types.h)"
+		SEL 					ObjCSelector
+		uint8_t 				uchar "Drill down from https://developer.apple.com/documentation/kernel/uint8_t?language=objc"
 	)
 ]
 

--- a/src/ObjectiveC/ObjCMethod.class.st
+++ b/src/ObjectiveC/ObjCMethod.class.st
@@ -1,5 +1,5 @@
 "
-I represent an Objective-C method definition.
+I represent the Objective-C Runtime's Method data type. See documention at https://developer.apple.com/documentation/objectivec/method?language=objc
 "
 Class {
 	#name : #ObjCMethod,

--- a/src/ObjectiveC/ObjCMethod.class.st
+++ b/src/ObjectiveC/ObjCMethod.class.st
@@ -4,14 +4,14 @@ I represent the Objective-C Runtime's Method data type. See documention at https
 Class {
 	#name : #ObjCMethod,
 	#superclass : #FFIExternalObject,
-	#traits : 'TObjCLibrary',
-	#classTraits : 'TObjCLibrary classTrait',
+	#traits : 'TObjCLibrary + TObjCInspectable',
+	#classTraits : 'TObjCLibrary classTrait + TObjCInspectable classTrait',
 	#category : #'ObjectiveC-Core'
 }
 
 { #category : #accessing }
-ObjCMethod >> argumentType: index [
-	^ self ffiCall: #(char *method_copyArgumentType(self, uint index))
+ObjCMethod >> argumentTypeDescriptions [
+	^ self argumentTypes collect: [ :e | e objCDecodeType ]
 ]
 
 { #category : #accessing }
@@ -19,13 +19,133 @@ ObjCMethod >> argumentTypes [
 	| types numArgs |
 	numArgs := self numArgs.
 	types := (Array new: numArgs) writeStream.
-	0 to: (numArgs - 1) do: [ :index | types nextPut: (self argumentType: index) ].
+	0 to: (numArgs - 1) do: [ :index | types nextPut: (self getArgumentTypeAt: index) ].
 	^ types contents
 ]
 
+{ #category : #'objective-c run-time' }
+ObjCMethod >> copyArgumentType: index [
+	"
+	Return value - a type code. See https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100.
+	
+	Function doc: 
+	https://developer.apple.com/documentation/objectivec/1418832-method_copyargumenttype?language=objc"
+	self error: 'How do we free the returned string?'.
+	"^ self ffiCall: #(char * method_copyArgumentType(Method self, uint index))"
+]
+
+{ #category : #'objective-c run-time' }
+ObjCMethod >> copyReturnType [
+	"
+	Return value - a type code. See https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100.
+	
+	Function doc: 
+	https://developer.apple.com/documentation/objectivec/1418777-method_copyreturntype?language=objc"
+	self error: 'How do we free the returned string?'.
+	"^ self ffiCall: #(char * method_copyReturnType(Method self))"
+]
+
+{ #category : #printing }
+ObjCMethod >> displayString [
+	^ self selector name
+]
+
+{ #category : #'objective-c run-time' }
+ObjCMethod >> exchangeImplementations [
+	"https://developer.apple.com/documentation/objectivec/1418769-method_exchangeimplementations?language=objc"
+	^ self shouldBeImplemented 
+]
+
 { #category : #private }
+ObjCMethod >> externalCharArrayDuring: aBlock [
+
+	| charArray result |
+	charArray := FFIArray externalNewType: #char size: 256.
+	aBlock value: charArray.
+	result := (charArray as: String) copyUpTo: Character null.
+	charArray getHandle free.
+	^ result
+]
+
+{ #category : #'objective-c run-time' }
+ObjCMethod >> getArgumentTypeAt: index [
+	"https://developer.apple.com/documentation/objectivec/1418607-method_getargumenttype?language=objc"
+
+	^ self externalCharArrayDuring: [ :array | self getArgumentTypeAt: index writeTo: array upToLength: array size ].
+]
+
+{ #category : #private }
+ObjCMethod >> getArgumentTypeAt: index writeTo: charArray upToLength: charArraySize [
+	"https://developer.apple.com/documentation/objectivec/1418607-method_getargumenttype?language=objc"
+	^ self ffiCall: #(void method_getArgumentType(Method self, uint index, char *charArray, size_t charArraySize))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCMethod >> getDescription [
+	"https://developer.apple.com/documentation/objectivec/1418545-method_getdescription?language=objc"
+	^ self ffiCall: #(struct objc_method_description * method_getDescription(Method self))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCMethod >> getImplementation [
+	"https://developer.apple.com/documentation/objectivec/1418551-method_getimplementation?language=objc"
+	^ self ffiCall: #(IMP method_getImplementation(Method self))
+]
+
+{ #category : #'objective-c run-time' }
 ObjCMethod >> getName [
-	^ self ffiCall: #(SEL method_getName(self))
+	"https://developer.apple.com/documentation/objectivec/1418758-method_getname?language=objc"
+	^ self ffiCall: #(SEL method_getName(Method self))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCMethod >> getReturnType [
+	"https://developer.apple.com/documentation/objectivec/1418591-method_getreturntype?language=objc"
+
+	^ self externalCharArrayDuring: [ :array | self getReturnType: array upTo: array size ].
+]
+
+{ #category : #private }
+ObjCMethod >> getReturnType: charArray upTo: charArraySize [
+	"https://developer.apple.com/documentation/objectivec/1418591-method_getreturntype?language=objc"
+	^ self ffiCall: #(void method_getReturnType(Method self, char *charArray, size_t charArraySize))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCMethod >> getTypeEncoding [
+	"https://developer.apple.com/documentation/objectivec/1418488-method_gettypeencoding?language=objc"
+	^ self ffiCall: #(const char * method_getTypeEncoding(Method self))
+]
+
+{ #category : #inspecting }
+ObjCMethod >> gtInspectorRuntimeIn: composite [
+	<gtInspectorPresentationOrder: 10>
+	
+	self 
+		gtInspectorObjCRuntimeFields: { 
+			'Name' -> self getName.
+			'Argument Types' -> (self argumentTypeDescriptions allButFirst: 2).
+			"'Implementation' -> (self getImplementation CALLOUT NOT WORKING)."
+			'Num. Arguments' -> (self numArgs - 2).
+			'Return Type' -> self returnType objCDecodeType.
+			'Type Encoding' -> self getTypeEncoding }
+		in: composite
+]
+
+{ #category : #'objective-c run-time' }
+ObjCMethod >> invoke [
+	"https://developer.apple.com/documentation/objectivec/1456726-method_invoke?language=objc"
+	self flag: 'In the header, the signature is `id _Nullable
+method_invoke(id _Nullable receiver, Method _Nonnull m, ...)`, but in the docs, it''s `void method_invoke(void)`'.
+	^ self shouldBeImplemented
+]
+
+{ #category : #'objective-c run-time' }
+ObjCMethod >> invoke_Stret [
+	"https://developer.apple.com/documentation/objectivec/1456726-method_invoke?language=objc"
+	self flag: 'In the header, the signature is `id _Nullable
+method_invoke(id _Nullable receiver, Method _Nonnull m, ...)`, but in the docs, it''s `void method_invoke(void)`'.
+	^ self shouldBeImplemented
 ]
 
 { #category : #accessing }
@@ -33,12 +153,33 @@ ObjCMethod >> name [
 	^ self getName name
 ]
 
-{ #category : #accessing }
+{ #category : #'objective-c run-time' }
 ObjCMethod >> numArgs [
-	^ self ffiCall: #(uint method_getNumberOfArguments(self))
+	"https://developer.apple.com/documentation/objectivec/1418968-method_getnumberofarguments?language=objc"
+	^ self ffiCall: #(uint method_getNumberOfArguments(Method self))
+]
+
+{ #category : #printing }
+ObjCMethod >> printOn: aStream [
+	super printOn: aStream.
+	aStream 
+		space;
+		nextPutAll: self selector name
 ]
 
 { #category : #accessing }
 ObjCMethod >> returnType [
-	^ self ffiCall: #(char *method_copyReturnType(self))
+	"https://developer.apple.com/documentation/objectivec/1418777-method_copyreturntype?language=objc"
+	^ self getReturnType
+]
+
+{ #category : #accessing }
+ObjCMethod >> selector [
+	^ self getName
+]
+
+{ #category : #'objective-c run-time' }
+ObjCMethod >> setImplementation [
+	"https://developer.apple.com/documentation/objectivec/1418707-method_setimplementation?language=objc"
+	^ self shouldBeImplemented 
 ]

--- a/src/ObjectiveC/ObjCMethod.class.st
+++ b/src/ObjectiveC/ObjCMethod.class.st
@@ -24,13 +24,13 @@ ObjCMethod >> argumentTypes [
 ]
 
 { #category : #private }
-ObjCMethod >> method_getName [
+ObjCMethod >> getName [
 	^ self ffiCall: #(SEL method_getName(self))
 ]
 
 { #category : #accessing }
 ObjCMethod >> name [
-	^ self method_getName name
+	^ self getName name
 ]
 
 { #category : #accessing }

--- a/src/ObjectiveC/ObjCMethodImplementation.class.st
+++ b/src/ObjectiveC/ObjCMethodImplementation.class.st
@@ -1,0 +1,10 @@
+"
+I represent Obj-C's IMP data type. See https://developer.apple.com/documentation/objectivec/objective-c_runtime/imp?language=objc
+"
+Class {
+	#name : #ObjCMethodImplementation,
+	#superclass : #FFIExternalObject,
+	#traits : 'TObjCLibrary',
+	#classTraits : 'TObjCLibrary classTrait',
+	#category : #'ObjectiveC-Core'
+}

--- a/src/ObjectiveC/ObjCObject.class.st
+++ b/src/ObjectiveC/ObjCObject.class.st
@@ -98,6 +98,7 @@ ObjCObject >> gtInspectorRuntimeFields [
 ObjCObject >> gtInspectorRuntimeIn: composite [
 	<gtInspectorPresentationOrder: 10>
 	
+	self getHandle isNull ifTrue: [ ^ self ].
 	self 
 		gtInspectorObjCRuntimeFields: self gtInspectorRuntimeFields
 		in: composite

--- a/src/ObjectiveC/ObjCObject.class.st
+++ b/src/ObjectiveC/ObjCObject.class.st
@@ -30,11 +30,6 @@ ObjCObject class >> nil [
 	^ self null
 ]
 
-{ #category : #private }
-ObjCObject >> class: aClass getInstanceMethod: aName [
-	^ self ffiCall: #(Method class_getInstanceMethod(Class aClass, SEL aName))
-]
-
 { #category : #accessing }
 ObjCObject >> descriptionString [ 
 	^ self description UTF8String
@@ -50,6 +45,24 @@ ObjCObject >> doesNotUnderstand: aMessage [
 	^ shadowMethod 
 		valueWithReceiver: self
 		arguments: arguments
+]
+
+{ #category : #'objective-c run-time' }
+ObjCObject >> getClass [
+	"https://developer.apple.com/documentation/objectivec/1418629-object_getclass?language=objc"
+	^ self ffiCall: #(Class object_getClass(self))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCObject >> getClassName [
+	"https://developer.apple.com/documentation/objectivec/1418547-object_getclassname?language=objc"
+	^ self ffiCall: #(const char * object_getClassName(self))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCObject >> getInstanceVariable [
+	"https://developer.apple.com/documentation/objectivec/1441499-object_getinstancevariable?language=objc"
+	^ self ffiCall: #(Ivar object_getInstanceVariable(self, const char *name, void **outValue))
 ]
 
 { #category : #private }
@@ -111,9 +124,7 @@ ObjCObject >> isa [
 
 { #category : #private }
 ObjCObject >> objCMethodForSelector: aSelector [
-	^ self 
-		class: self isa
-		getInstanceMethod: aSelector asObjCSelector
+	^ self isa getInstanceMethod: aSelector asObjCSelector
 ]
 
 { #category : #private }

--- a/src/ObjectiveC/ObjCObject.class.st
+++ b/src/ObjectiveC/ObjCObject.class.st
@@ -170,6 +170,18 @@ ObjCObject >> objCPerform: aSEL [
 	^ self ffiCall: #(id objc_msgSend(self, SEL aSEL))
 ]
 
+{ #category : #'message performing' }
+ObjCObject >> objCSend: aMessage [
+	"Force a message to be sent on the Obj-C side. This is useful when there is a message with the same selector on the Pharo side (e.g. #class), which would otherwise intercept it"
+	^ self doesNotUnderstand: aMessage
+]
+
+{ #category : #'message performing' }
+ObjCObject >> performObjC: selector withArguments: argArray [ 
+	"See objCSend: comment"
+	^ self objCSend: (Message selector: selector arguments: argArray)
+]
+
 { #category : #accessing }
 ObjCObject >> release [
 	self objCPerform: #release asObjCSelector

--- a/src/ObjectiveC/ObjCObject.class.st
+++ b/src/ObjectiveC/ObjCObject.class.st
@@ -4,8 +4,8 @@ I represent an Objective-C instance.
 Class {
 	#name : #ObjCObject,
 	#superclass : #FFIExternalObject,
-	#traits : 'TObjCLibrary',
-	#classTraits : 'TObjCLibrary classTrait',
+	#traits : 'TObjCLibrary + TObjCInspectable',
+	#classTraits : 'TObjCLibrary classTrait + TObjCInspectable classTrait',
 	#instVars : [
 		'isa'
 	],
@@ -56,13 +56,51 @@ ObjCObject >> getClass [
 { #category : #'objective-c run-time' }
 ObjCObject >> getClassName [
 	"https://developer.apple.com/documentation/objectivec/1418547-object_getclassname?language=objc"
-	^ self ffiCall: #(const char * object_getClassName(self))
+	^ self ffiCall: #(const char * object_getClassName(id self))
 ]
 
 { #category : #'objective-c run-time' }
 ObjCObject >> getInstanceVariable [
 	"https://developer.apple.com/documentation/objectivec/1441499-object_getinstancevariable?language=objc"
 	^ self ffiCall: #(Ivar object_getInstanceVariable(self, const char *name, void **outValue))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCObject >> getInstanceVariable: aString [
+	"https://developer.apple.com/documentation/objectivec/1441499-object_getinstancevariable?language=objc"
+	| outValue |
+	outValue := FFIOop newBuffer.
+	^ { self getInstanceVariable: aString value: outValue. outValue }
+]
+
+{ #category : #'objective-c run-time' }
+ObjCObject >> getInstanceVariable: name value: outValue [
+	"https://developer.apple.com/documentation/objectivec/1441499-object_getinstancevariable?language=objc"
+	^ self ffiCall: #(Ivar object_getInstanceVariable(id self, const char *name, void **outValue))
+]
+
+{ #category : #'objective-c run-time' }
+ObjCObject >> getInstanceVariableValue: aString [
+	"https://developer.apple.com/documentation/objectivec/1441499-object_getinstancevariable?language=objc"
+	| outValue |
+	outValue := ExternalAddress new.
+	^ { self getInstanceVariable: aString value: outValue. outValue }
+]
+
+{ #category : #inspecting }
+ObjCObject >> gtInspectorRuntimeFields [
+	^ { 
+		'Class' -> self getClass.
+		'Class Name' -> self getClassName. }
+]
+
+{ #category : #inspecting }
+ObjCObject >> gtInspectorRuntimeIn: composite [
+	<gtInspectorPresentationOrder: 10>
+	
+	self 
+		gtInspectorObjCRuntimeFields: self gtInspectorRuntimeFields
+		in: composite
 ]
 
 { #category : #private }

--- a/src/ObjectiveC/ObjCProperty.class.st
+++ b/src/ObjectiveC/ObjCProperty.class.st
@@ -1,0 +1,16 @@
+"
+I represent the Objective-C Runtime's Property data type. See documention at https://developer.apple.com/documentation/objectivec/objc_property_t?language=objc
+"
+Class {
+	#name : #ObjCProperty,
+	#superclass : #FFIExternalObject,
+	#traits : 'TObjCLibrary',
+	#classTraits : 'TObjCLibrary classTrait',
+	#category : #'ObjectiveC-Core'
+}
+
+{ #category : #accessing }
+ObjCProperty >> getName [
+	"https://developer.apple.com/documentation/objectivec/1418903-property_getname?language=objc"
+	^ self ffiCall: #(const char * property_getName(self))
+]

--- a/src/ObjectiveC/ObjCProperty.class.st
+++ b/src/ObjectiveC/ObjCProperty.class.st
@@ -4,10 +4,15 @@ I represent the Objective-C Runtime's Property data type. See documention at htt
 Class {
 	#name : #ObjCProperty,
 	#superclass : #FFIExternalObject,
-	#traits : 'TObjCLibrary',
-	#classTraits : 'TObjCLibrary classTrait',
+	#traits : 'TObjCLibrary + TObjCInspectable',
+	#classTraits : 'TObjCLibrary classTrait + TObjCInspectable classTrait',
 	#category : #'ObjectiveC-Core'
 }
+
+{ #category : #displaying }
+ObjCProperty >> displayString [
+	^ self getName
+]
 
 { #category : #accessing }
 ObjCProperty >> getName [

--- a/src/ObjectiveC/ObjCProtocol.class.st
+++ b/src/ObjectiveC/ObjCProtocol.class.st
@@ -1,0 +1,22 @@
+"
+I represent the Objective-C Runtime's Protocol class. See documention at https://developer.apple.com/documentation/objectivec/protocol?language=objc
+"
+Class {
+	#name : #ObjCProtocol,
+	#superclass : #FFIExternalObject,
+	#traits : 'TObjCLibrary',
+	#classTraits : 'TObjCLibrary classTrait',
+	#category : #'ObjectiveC-Core'
+}
+
+{ #category : #accessing }
+ObjCProtocol class >> getProtocol: aName [
+	"https://developer.apple.com/documentation/objectivec/1418870-objc_getprotocol?language=objc"
+	^ self ffiCall: #(Protocol * objc_getProtocol(const char *aName))
+]
+
+{ #category : #accessing }
+ObjCProtocol >> getName [
+	"https://developer.apple.com/documentation/objectivec/1418826-protocol_getname?language=objc"
+	^ self ffiCall: #(const char * protocol_getName(self))
+]

--- a/src/ObjectiveC/ObjCProtocol.class.st
+++ b/src/ObjectiveC/ObjCProtocol.class.st
@@ -3,9 +3,9 @@ I represent the Objective-C Runtime's Protocol class. See documention at https:/
 "
 Class {
 	#name : #ObjCProtocol,
-	#superclass : #FFIExternalObject,
-	#traits : 'TObjCLibrary',
-	#classTraits : 'TObjCLibrary classTrait',
+	#superclass : #FFIOpaqueObject,
+	#traits : 'TObjCLibrary + TObjCInspectable',
+	#classTraits : 'TObjCLibrary classTrait + TObjCInspectable classTrait',
 	#category : #'ObjectiveC-Core'
 }
 
@@ -13,6 +13,11 @@ Class {
 ObjCProtocol class >> getProtocol: aName [
 	"https://developer.apple.com/documentation/objectivec/1418870-objc_getprotocol?language=objc"
 	^ self ffiCall: #(Protocol * objc_getProtocol(const char *aName))
+]
+
+{ #category : #displaying }
+ObjCProtocol >> displayString [
+	^ self getName
 ]
 
 { #category : #accessing }

--- a/src/ObjectiveC/ObjCSelector.class.st
+++ b/src/ObjectiveC/ObjCSelector.class.st
@@ -4,8 +4,8 @@ I represent an Objective-C selector.
 Class {
 	#name : #ObjCSelector,
 	#superclass : #FFIExternalObject,
-	#traits : 'TObjCLibrary',
-	#classTraits : 'TObjCLibrary classTrait',
+	#traits : 'TObjCLibrary + TObjCInspectable',
+	#classTraits : 'TObjCLibrary classTrait + TObjCInspectable classTrait',
 	#category : #'ObjectiveC-Core'
 }
 
@@ -26,12 +26,17 @@ ObjCSelector >> asNSString [
 	^ self ffiCall: #(NSString *NSStringFromSelector(SEL self))
 ]
 
-{ #category : #private }
+{ #category : #displaying }
+ObjCSelector >> displayString [
+	^ self name
+]
+
+{ #category : #'objective-c run-time' }
 ObjCSelector >> getName [
 	^ self ffiCall: #(const char *sel_getName(SEL self))
 ]
 
 { #category : #accessing }
 ObjCSelector >> name [
-	^ self ffiCall: #(char *sel_getName(self))
+	^ self getName
 ]

--- a/src/ObjectiveC/ObjCSelector.class.st
+++ b/src/ObjectiveC/ObjCSelector.class.st
@@ -21,12 +21,17 @@ ObjCSelector class >> sel_registerName: str [
 	^ self ffiCall: #(SEL sel_registerName(const char *str))
 ]
 
-{ #category : #accessing }
-ObjCSelector >> name [
-	^ self ffiCall: #(char *sel_getName(self))
+{ #category : #private }
+ObjCSelector >> asNSString [
+	^ self ffiCall: #(NSString *NSStringFromSelector(SEL self))
 ]
 
 { #category : #private }
-ObjCSelector >> sel_getName [
+ObjCSelector >> getName [
+	^ self ffiCall: #(const char *sel_getName(SEL self))
+]
+
+{ #category : #accessing }
+ObjCSelector >> name [
 	^ self ffiCall: #(char *sel_getName(self))
 ]

--- a/src/ObjectiveC/String.extension.st
+++ b/src/ObjectiveC/String.extension.st
@@ -13,6 +13,13 @@ String >> adaptToObjC [
 ]
 
 { #category : #'*ObjectiveC' }
+String >> asObjCFourCharCode [
+	"Adapted from https://stackoverflow.com/a/31321444"
+
+	^ self inject: 0 into: [ :sum :e | (sum << 8) + e asciiValue ]
+]
+
+{ #category : #'*ObjectiveC' }
 String >> inObjC [
 	^ ObjCClass lookup: self asString
 ]

--- a/src/ObjectiveC/TObjCInspectable.trait.st
+++ b/src/ObjectiveC/TObjCInspectable.trait.st
@@ -1,0 +1,23 @@
+Trait {
+	#name : #TObjCInspectable,
+	#category : #'ObjectiveC-Core'
+}
+
+{ #category : #inspecting }
+TObjCInspectable >> gtInspectorObjCRuntimeFields: anArray in: composite [
+	
+	composite fastTreeTable
+		title: 'Runtime (ObjC)';
+		hasChildren: [ :e | e value isArray and: [ e isKindOf: Association ] ];
+		display: [ anArray ];
+		column: 'Field' translated evaluated: [  :e | (e isKindOf: Association) ifTrue: [ e key ] ifFalse: [ e displayString ] ];
+		column: 'Value' translated evaluated: [  :e | 
+			e value isArray 
+				ifTrue: [ e value size asString, ' items' ] 
+				ifFalse: [ 
+					((e value respondsTo: #isNull) and: [ e value isNull ]) 
+						ifTrue: [ 'null' ] 
+						ifFalse: [ e value ] ] ];
+		children: [ :e | e value ];
+		send: #value
+]


### PR DESCRIPTION
DO NOT INTEGRATE!!! Conversation starter...

See docs at https://developer.apple.com/documentation/objectivec?language=objc

Run the tests and you'll see where I'm stuck.

Trouble spots: 
- Returning an array of pointers to an ExternalObject. See `#returnArrayFrom:AsInstancesOf:` and senders
- Arguments used to pass back strings which need to be freed. See `#externalCharArrayDuring:` and senders.
- IMP Obj-C type is currently defined as ObjCProxyCallback, but it's not always used that way. See `#getImplementation`
- ObjCObject >> #getInstanceVariable:...` is WIP

To play with the code:
```smalltalk
"On 64-bit Pharo 8 with headless VM via Launcher..."

Metacello new
		baseline: 'ThreadedFFI';
		repository: 'github://pharo-project/threadedFFI-Plugin';
		onConflictUseLoaded;
		load.

Metacello new 
  repository: 'github://estebanlm/objcbridge/src';
  baseline: 'ObjCBridge'.```

Inspect: `#NSObject inObjC.`, click on the `Runtime ObjC` GT-Inspector tab, and happy exploring!!